### PR TITLE
fix: correct course name from "CS 321N" to "CS231N" in resources.md

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -26,7 +26,7 @@ If there are resources that you've found helpful but not yet included, feel free
 ## ML Theory Fundamentals
 While you don't need an ML background to start building with foundation models, a rough understanding of how AI works under the hood is useful to prevent misuse. Familiarity with ML theory will make you much more effective.
 
-1. [Lecture notes] [Stanford CS 321N](https://cs231n.github.io/): a longtime favorite introductory course on neural networks.
+1. [Lecture notes] [Stanford CS231N](https://cs231n.github.io/): a longtime favorite introductory course on neural networks.
     
     - [Videos] I'd recommend watching lectures 1 to 7 from the 2017 course [video recordings](https://www.youtube.com/watch?v=vT1JzLTH4G4&list=PL3FW7Lu3i5JvHM8ljYj-zLfQRF3EO8sYv). They cover the fundamentals that haven't changed.
     - [Videos] Andrej Karpathy's [Neural Networks: Zero to Hero](https://www.youtube.com/playlist?list=PLAqhIrjkxbuWI23v9cThsA9GvCAUhRvKZ) is more hands-on where he shows how to implement several models from scratch.


### PR DESCRIPTION
## Summary

Fixes a typo in `resources.md` where the Stanford neural networks course was listed as **CS 321N** (with an erroneous space) instead of the correct **CS231N**.

## Change

| File | Line | Before | After |
|------|------|--------|-------|
| `resources.md` | 29 | `Stanford CS 321N` | `Stanford CS231N` |

The hyperlink URL (`https://cs231n.github.io/`) was already correct; only the display text needed fixing.

## Why it matters

Readers who search for "CS 321N" will not find the course. The correct designation is CS231N, consistent with how Stanford, Andrej Karpathy, and the wider community refer to the course.

Closes #25

---
*Signed-off-by: Cocoon-Break <54054995+kuishou68@users.noreply.github.com>*