### PR TITLE
Add MiniMax-M3 mmx-cli skill for AI-powered content generation

### DIFF
--- a/skills/mmx-cli/SKILL.md
+++ b/skills/mmx-cli/SKILL.md
@@ -2,7 +2,8 @@
 name: mmx-cli
 description: >
   Generate text, images, video, speech, and music via the MiniMax AI platform.
-  Covers text generation (MiniMax-M2.7 model), image generation (image-01),
+  Covers text generation (MiniMax-M3 model, with MiniMax-M2.7 and
+  MiniMax-M2.7-highspeed as alternatives), image generation (image-01),
   video generation (Hailuo-2.3), speech synthesis (speech-2.8-hd, 300+ voices),
   music generation (music-2.6 with lyrics, cover, and instrumental), and web search.
   Use when the user needs to create AI-generated multimedia content, produce
@@ -36,12 +37,14 @@ export MINIMAX_API_KEY=your_api_key_here
 
 | Capability | Command | Model |
 |------------|---------|-------|
-| Text generation | `mmx text generate` | MiniMax-M2.7 |
+| Text generation | `mmx text generate` | MiniMax-M3 (default), MiniMax-M2.7, MiniMax-M2.7-highspeed |
 | Image generation | `mmx image generate` | image-01 |
 | Video generation | `mmx video generate` | Hailuo-2.3 |
 | Speech synthesis | `mmx speech generate` | speech-2.8-hd |
 | Music generation | `mmx music generate` | music-2.6 |
 | Web search | `mmx search` | — |
+
+The default text generation model is `MiniMax-M3` (512K context window, up to 128K output, image input supported). Use `--model MiniMax-M2.7` or `--model MiniMax-M2.7-highspeed` to select an alternative.
 
 ## Quick Examples
 

--- a/skills/mmx-cli/SKILL.md
+++ b/skills/mmx-cli/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: mmx-cli
+description: >
+  Generate text, images, video, speech, and music via the MiniMax AI platform.
+  Covers text generation (MiniMax-M2.7 model), image generation (image-01),
+  video generation (Hailuo-2.3), speech synthesis (speech-2.8-hd, 300+ voices),
+  music generation (music-2.6 with lyrics, cover, and instrumental), and web search.
+  Use when the user needs to create AI-generated multimedia content, produce
+  narrated audio from text, compose music, or search the web through MiniMax AI services.
+---
+
+# mmx-cli Skill
+
+Generate multimedia content (text, images, video, speech, music) via the
+[MiniMax AI](https://github.com/MiniMax-AI/cli) platform.
+
+## Install
+
+```bash
+npx skills add MiniMax-AI/cli@skill -g -y
+```
+
+Or manually:
+
+```bash
+npm install -g @minimax-ai/cli
+```
+
+Set your API key:
+
+```bash
+export MINIMAX_API_KEY=your_api_key_here
+```
+
+## Capabilities
+
+| Capability | Command | Model |
+|------------|---------|-------|
+| Text generation | `mmx text generate` | MiniMax-M2.7 |
+| Image generation | `mmx image generate` | image-01 |
+| Video generation | `mmx video generate` | Hailuo-2.3 |
+| Speech synthesis | `mmx speech generate` | speech-2.8-hd |
+| Music generation | `mmx music generate` | music-2.6 |
+| Web search | `mmx search` | — |
+
+## Quick Examples
+
+```bash
+# Generate text
+mmx text generate "Summarize the key benefits of reinforcement learning from human feedback"
+
+# Generate an image
+mmx image generate "A diagram of a RAG architecture with vector database"
+
+# Generate a short video clip
+mmx video generate "An AI engineer working at a laptop surrounded by floating neural network nodes"
+
+# Synthesize speech from text
+mmx speech generate --text "Welcome to AI Engineering." --voice Calm_Woman
+
+# Generate music with lyrics
+mmx music generate --lyrics "Code and data, night and day" --style "upbeat tech"
+
+# Web search
+mmx search "latest advances in LLM evaluation benchmarks"
+```
+
+## Gather from user before running
+
+| Info | Required? | Notes |
+|------|-----------|-------|
+| MINIMAX_API_KEY | Yes | From [MiniMax platform](https://www.minimaxi.com/) |
+| Prompt or text | Yes | Describe what to generate |
+| Voice name | No | For speech; run `mmx speech list-voices` to browse 300+ options |
+| Output path | No | Default saves to current directory |
+
+## Tips
+
+- Use `--output json` flag for structured output suitable for pipelines.
+- Use `--non-interactive` and `--quiet` flags in automated / agent workflows.
+- Run `mmx --help` or `mmx <subcommand> --help` to see all options.
+- The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md)
+  in the upstream repo is always up-to-date with the latest flags and models.


### PR DESCRIPTION
## Summary

- Adds `skills/mmx-cli/SKILL.md` to enable AI agents working with this repository to use the MiniMax AI platform
- Supports text generation via **MiniMax-M3** (default, with MiniMax-M2.7 and MiniMax-M2.7-highspeed as alternatives), image generation (image-01), video generation (Hailuo-2.3), speech synthesis (speech-2.8-hd), music generation (music-2.6), and web search
- Follows the standard `SKILL.md` format used by OpenClaw and compatible AI agent platforms

## Motivation

As an AI Engineering resource repository used by practitioners building AI applications, adding an `mmx-cli` skill enables AI agents working alongside engineers with this repo to generate multimedia content (diagrams, audio narrations, example videos) directly via MiniMax's API. The default text model is the latest **MiniMax-M3** (512K context window, up to 128K output, image input supported).

## Changes

- `skills/mmx-cli/SKILL.md` — new file describing install steps, capabilities table, quick examples, and usage tips for the MiniMax CLI
- Default text generation model is `MiniMax-M3`; `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` are still available as alternatives

## Test plan

- [x] SKILL.md frontmatter is valid YAML with `name` and `description` fields
- [x] All CLI examples reference real `mmx` subcommands (`text generate`, `image generate`, `video generate`, `speech generate`, `music generate`, `search`)
- [x] Install instructions match the upstream [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli) README