### PR TITLE
Fix broken Chapter 7 link (mlops.systems → alexstrick.com) 

### DIFF
--- a/study-notes.md
+++ b/study-notes.md
@@ -3,7 +3,7 @@ Notes from people reading AI Engineering. If you've made public notes about the 
 
 - [Alex Strick van Linschoten](https://www.linkedin.com/in/strickvl/) made excellent chapter-by-chapter notes of the book. Here are some of them.
     - [Chapter 6: RAG and Agents](https://mlops.systems/posts/2025-01-24-notes-on-ai-engineering-chip-huyen-chapter-6.html)
-    - [Chapter 7: Finetuning](https://mlops.systems/posts/2025-01-26-notes-on-ai-engineering-chip-huyen-chapter-7:-finetuning.html)
+    - [Chapter 7: Finetuning](https://alexstrick.com/posts/2025-01-26-notes-on-ai-engineering-chip-huyen-chapter-7-finetuning.html)
     - [Chapter 9: Inference optimization](https://mlops.systems/posts/2025-02-07-ai-engineering-chapter-9.html)
     - [Chapter 10: AI engineering architecture and user feedback](https://mlops.systems/posts/2025-02-09-ai-eg-chapter-10.html)
 - [Li Liu's bookclub](https://docs.google.com/document/d/1mKRI3cJVNTmNKgE85OUd3DOfnph7Z3QmqrZhBCX7yQ4/edit?tab=t.0#heading=h.ohq29zbftwgr): started Feb 8, 2025 with weekly meeting.


### PR DESCRIPTION
The Chapter 7 link points to mlops.systems which returns a 404. The correct URL is on alexstrick.com.